### PR TITLE
Correct changelog for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ See [GitHub releases](https://github.com/mll-lab/laravel-comment/releases).
 
 ### Added
 
-- Support Laravel 9
+- Support Laravel 10
 
 ## 1.2.0
 


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Documented user facing changes
- [x] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

Version 1.3.0 states it added support for Laravel 9, but that should be Laravel 10.
